### PR TITLE
issue while installing this package

### DIFF
--- a/R/networkPlot.R
+++ b/R/networkPlot.R
@@ -252,10 +252,10 @@ enrichmentNetwork.connect <- function(sim, clusters, innerCutoff = 0.1, outerCut
   coordinates[ , ID := V(g) %>% as.list %>% names ]
 
   edges %>%
-    .[ , xStart := lapply(from, \(path) coordinates[ ID %in% path, x ]) %>% unlist ] %>%
-    .[ , yStart := lapply(from, \(path) coordinates[ ID %in% path, y ]) %>% unlist ] %>%
-    .[ , xEnd := lapply(to, \(path) coordinates[ ID %in% path, x ]) %>% unlist ] %>%
-    .[ , yEnd := lapply(to, \(path) coordinates[ ID %in% path, y ]) %>% unlist ]
+    .[ , xStart := lapply(from, function(path) coordinates[ ID %in% path, x ]) %>% unlist ] %>%
+    .[ , yStart := lapply(from, function(path) coordinates[ ID %in% path, y ]) %>% unlist ] %>%
+    .[ , xEnd := lapply(to, function(path) coordinates[ ID %in% path, x ]) %>% unlist ] %>%
+    .[ , yEnd := lapply(to, function(path) coordinates[ ID %in% path, y ]) %>% unlist ]
 
   list(coordinates = coordinates,
        edges = edges)

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -117,5 +117,5 @@ getGenes <- function(enrichment, geneCol, pathCol = 'Description') {
 
   enrichment[ , cols ] %>%
     deframe %>%
-    lapply(\(x) strsplit(x, split = '/')[[1]])
+    lapply(function(x) strsplit(x, split = '/')[[1]])
 }

--- a/README.md
+++ b/README.md
@@ -7,15 +7,14 @@
 ### Install latest stable version
 
 ```R
-library(devtools)
-install_github('ievaKer/pathExplore')
+install.packages("devtools")
+devtools::install_github('ievaKer/pathExplore')
 ```
 
 ### Install latest beta version
 
 ```R
-library(devtools)
-install_github('ievaKer/pathExplore@development')
+devtools::install_github('ievaKer/pathExplore@development')
 ```
 
 ### Run an example

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ```R
 install.packages("devtools")
+install.packages("ggrepel")
 devtools::install_github('ievaKer/pathExplore')
 ```
 
@@ -18,6 +19,13 @@ devtools::install_github('ievaKer/pathExplore@development')
 ```
 
 ### Run an example
+
+```R
+devtools::install_git('https://git.bioconductor.org/packages/clusterProfiler')
+install.packages("BiocManager")
+BiocManager::install("org.Hs.eg.db")
+devtools::install_git("https://git.bioconductor.org/packages/DOSE")
+```
 
 ```R
 library(pathExplore)


### PR DESCRIPTION
A problem has arisen with the installation of this package. This fixes it. Also, more information has also been added on how to install the required packages.

```R
> devtools::install_github('ievaKer/pathExplore')
Downloading GitHub repo ievaKer/pathExplore@HEAD
✔  checking for file ‘/tmp/RtmpObPlv6/remotes790801852e11f/ievaKer-pathExplore-5076e40/DESCRIPTION’ ...
─  preparing ‘pathExplore’:
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
   Removed empty directory ‘pathExplore/evaluation’
   Removed empty directory ‘pathExplore/examples’
   Removed empty directory ‘pathExplore/images’
   Removed empty directory ‘pathExplore/results’
─  building ‘pathExplore_1.0.tar.gz’
   
Installing package into ‘/home/domas/R/x86_64-pc-linux-gnu-library/4.0’
(as ‘lib’ is unspecified)
* installing *source* package ‘pathExplore’ ...
** using staged installation
** R
Error in parse(outFile) : 
  /tmp/RtmpPYmY4a/R.INSTALL84ec316c00ad9/pathExplore/R/networkPlot.R:255:33: unexpected input
254:   edges %>%
255:     .[ , xStart := lapply(from, \
                                     ^
ERROR: unable to collate and parse R files for package ‘pathExplore’
* removing ‘/home/domas/R/x86_64-pc-linux-gnu-library/4.0/pathExplore’
* restoring previous ‘/home/domas/R/x86_64-pc-linux-gnu-library/4.0/pathExplore’
Warning message:
In i.p(...) :
  installation of package ‘/tmp/RtmpObPlv6/file79080d436514/pathExplore_1.0.tar.gz’ had non-zero exit status
```

Environment:
R: 4.0.4
OS: Ubuntu 21.10
